### PR TITLE
Support `@codama/nodes@1.10` optional array attributes

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,10 +50,10 @@
         "test:unit": "vitest run"
     },
     "dependencies": {
-        "@codama/errors": "^1.8.0",
-        "@codama/nodes": "^1.8.0",
-        "@codama/renderers-core": "^1.3.9",
-        "@codama/visitors-core": "^1.8.0",
+        "@codama/errors": "^1.10.0",
+        "@codama/nodes": "^1.10.0",
+        "@codama/renderers-core": "^1.3.11",
+        "@codama/visitors-core": "^1.10.0",
         "@solana/codecs-strings": "^7.0.0"
     },
     "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,17 +9,17 @@ importers:
   .:
     dependencies:
       '@codama/errors':
-        specifier: ^1.8.0
-        version: 1.8.0
+        specifier: ^1.10.0
+        version: 1.10.0
       '@codama/nodes':
-        specifier: ^1.8.0
-        version: 1.8.0
+        specifier: ^1.10.0
+        version: 1.10.0
       '@codama/renderers-core':
-        specifier: ^1.3.9
-        version: 1.3.9
+        specifier: ^1.3.11
+        version: 1.3.11
       '@codama/visitors-core':
-        specifier: ^1.8.0
-        version: 1.8.0
+        specifier: ^1.10.0
+        version: 1.10.0
       '@solana/codecs-strings':
         specifier: ^7.0.0
         version: 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
@@ -296,24 +296,24 @@ packages:
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
 
-  '@codama/errors@1.8.0':
-    resolution: {integrity: sha512-A0FNhbfS1PBSK0nS+g65IR8+OKkifuIJCCnLCUBXb+I/OYMGlJMycMpU4pwAEEGS5GAnue7D/llXE+KpUaMi8w==}
+  '@codama/errors@1.10.0':
+    resolution: {integrity: sha512-/qiWQcbPIsyFlP1LrLqJfHt1QNbkY2wtC4UxZyKLnuZtc62YPlgDrN2wp4wcfRuE/DC0n3Y6ZSwYUrDBZyAnvA==}
     hasBin: true
 
-  '@codama/fragments@0.1.1':
-    resolution: {integrity: sha512-+DeC2YklyYf+qjRkoTKeG6HFgwsW7hiQko7er18dgsxF15M316EwYL2W40nKDPWlEhB/iME+sZR5++VQPUO/6w==}
+  '@codama/fragments@0.1.3':
+    resolution: {integrity: sha512-ITa3UYs74AWx7se/6EZN+YXqV1Vu89L3n2v0/irsQNbPcy8wP26p/GKns/1H4a8vGvAKuzWdIGO535dwcauInw==}
 
-  '@codama/node-types@1.8.0':
-    resolution: {integrity: sha512-KE9K9jjEdeFKtDKRrjjm5YwEkg7l+YwoWiH2w1UXJL/x6P5uul6+O5WnGsJn8IFtBVSLN4hbD7YSsZ0/lktJxQ==}
+  '@codama/node-types@1.10.0':
+    resolution: {integrity: sha512-fMoJQ8TgB9A5Pl+GA8ffhDbGK63cV1nrbDrYTgIhPDKeVqBSdkSAoAuAtvWfRd7X2ML73H6RRi6jZRJmo2xfHQ==}
 
-  '@codama/nodes@1.8.0':
-    resolution: {integrity: sha512-rl+7BxYatAE6uq5h9b5fEilGLd3YeJaJxqgLDAvdKQ5pspq6ch5ww9NiigkwdvDYli1Yk56PRhMZdLsiZIVgAA==}
+  '@codama/nodes@1.10.0':
+    resolution: {integrity: sha512-P3NXVw6kZq2VDb4wYU6zQ3xFksDqSuDYqp11P6Dpei9XIZZ11NtL2jBjBcqsIudGIx104bMgSo4SZ7Hlej056A==}
 
-  '@codama/renderers-core@1.3.9':
-    resolution: {integrity: sha512-DwMxltM+cldAK+rgtE3jVOmrGZuP7fA/ZLu6vgrsQYBp5dkOXCyiGBdpAz0VlhxaN4lB5TzT2Ia+EVv5G4YdGQ==}
+  '@codama/renderers-core@1.3.11':
+    resolution: {integrity: sha512-VSGrfmwPVv5cRAiHitgIq+rc9ktIN/Q9czbUORaqhZCmM+M3Ux5cd5r90PVTbeIt8vI0Zlw74OUFwdKqdEfSNw==}
 
-  '@codama/visitors-core@1.8.0':
-    resolution: {integrity: sha512-CLO0icVvzAutjI7imuN1Rib0/GIBc7hhwQ5gcE3aVAVBHUNS4M27BzagqYTpL0cMC9I1tL9c6lhpCBV2kKs6Zg==}
+  '@codama/visitors-core@1.10.0':
+    resolution: {integrity: sha512-8koBGs4m/NI4nDLJZx7Q1KzRUKkBy/GAnZq4xOEFGlhTvDCIAzEgo3biAhNFynGY45gzZJSX08QTDWKsPRjnaA==}
 
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
@@ -3602,34 +3602,34 @@ snapshots:
       human-id: 4.2.0
       prettier: 2.8.8
 
-  '@codama/errors@1.8.0':
+  '@codama/errors@1.10.0':
     dependencies:
-      '@codama/node-types': 1.8.0
+      '@codama/node-types': 1.10.0
       commander: 14.0.2
       picocolors: 1.1.1
 
-  '@codama/fragments@0.1.1':
+  '@codama/fragments@0.1.3':
     dependencies:
-      '@codama/errors': 1.8.0
+      '@codama/errors': 1.10.0
 
-  '@codama/node-types@1.8.0': {}
+  '@codama/node-types@1.10.0': {}
 
-  '@codama/nodes@1.8.0':
+  '@codama/nodes@1.10.0':
     dependencies:
-      '@codama/errors': 1.8.0
-      '@codama/node-types': 1.8.0
+      '@codama/errors': 1.10.0
+      '@codama/node-types': 1.10.0
 
-  '@codama/renderers-core@1.3.9':
+  '@codama/renderers-core@1.3.11':
     dependencies:
-      '@codama/errors': 1.8.0
-      '@codama/fragments': 0.1.1
-      '@codama/nodes': 1.8.0
-      '@codama/visitors-core': 1.8.0
+      '@codama/errors': 1.10.0
+      '@codama/fragments': 0.1.3
+      '@codama/nodes': 1.10.0
+      '@codama/visitors-core': 1.10.0
 
-  '@codama/visitors-core@1.8.0':
+  '@codama/visitors-core@1.10.0':
     dependencies:
-      '@codama/errors': 1.8.0
-      '@codama/nodes': 1.8.0
+      '@codama/errors': 1.10.0
+      '@codama/nodes': 1.10.0
       json-stable-stringify: 1.3.0
 
   '@emnapi/core@1.10.0':
@@ -4455,8 +4455,8 @@ snapshots:
 
   '@typescript-eslint/project-service@8.43.0(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.43.0(typescript@5.9.3)
-      '@typescript-eslint/types': 8.43.0
+      '@typescript-eslint/tsconfig-utils': 8.65.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.65.0
       debug: 4.4.3
       typescript: 5.9.3
     transitivePeerDependencies:

--- a/src/fragments/instructionPage.ts
+++ b/src/fragments/instructionPage.ts
@@ -80,7 +80,7 @@ function getInstructionStructFragment(
     instructionArguments: ParsedInstructionArgument[],
 ) {
     const accountsFragment = mergeFragments(
-        instructionNode.accounts.map(account => {
+        (instructionNode.accounts ?? []).map(account => {
             const docs = getDocblockFragment(account.docs ?? [], true);
             const name = snakeCase(account.name);
             const type = addFragmentImports(
@@ -122,7 +122,7 @@ function getInstructionImplFragment(
     instructionFixedSize: number | null,
 ) {
     const accountMetasFragment = mergeFragments(
-        instructionNode.accounts.map(account => {
+        (instructionNode.accounts ?? []).map(account => {
             const name = snakeCase(account.name);
             const isWritable = account.isWritable ? 'true' : 'false';
             const accountMetaArguments =
@@ -135,7 +135,7 @@ function getInstructionImplFragment(
     );
 
     const accountsFragment = mergeFragments(
-        instructionNode.accounts.map(account => {
+        (instructionNode.accounts ?? []).map(account => {
             const name = snakeCase(account.name);
             return fragment`&self.${name},`;
         }),
@@ -159,7 +159,7 @@ function getInstructionImplFragment(
     pub fn invoke_signed(&self, signers: &[Signer]) -> ProgramResult {
 
       // account metas
-      let account_metas: [AccountMeta; ${instructionNode.accounts.length}] = [
+      let account_metas: [AccountMeta; ${(instructionNode.accounts ?? []).length}] = [
         ${accountMetasFragment}
       ];
 
@@ -284,7 +284,7 @@ function getParsedInstructionArguments(
         parentName: `${pascalCase(instructionNode.name)}InstructionData`,
     });
 
-    return instructionNode.arguments.map(argument => {
+    return (instructionNode.arguments ?? []).map(argument => {
         const fixedSize = visit(argument.type, scope.byteSizeVisitor);
         const shouldUseLifetime = fixedSize === null || fixedSize > 8;
 
@@ -309,7 +309,7 @@ function getParsedInstructionArguments(
 
 function getLifetimeIterator(instructionNode: InstructionNode): Iterator<string, string> {
     // Start from 'b instead of 'a if we have accounts.
-    let lifetime = instructionNode.accounts.length > 0 ? 1 : 0;
+    let lifetime = (instructionNode.accounts ?? []).length > 0 ? 1 : 0;
     return {
         next: () => {
             if (lifetime >= 26) {
@@ -326,7 +326,7 @@ function getLifetimeDeclarations(
     useUnderscore = false,
 ): string {
     const lifetimes = [
-        ...(instructionNode.accounts.length > 0 ? [useUnderscore ? `'_` : `'a`] : []),
+        ...((instructionNode.accounts ?? []).length > 0 ? [useUnderscore ? `'_` : `'a`] : []),
         ...instructionArguments.flatMap(arg => (arg.lifetime ? [useUnderscore ? `'_` : `'${arg.lifetime}`] : [])),
     ];
     return lifetimes.length > 0 ? `<${lifetimes.join(', ')}>` : '';
@@ -334,8 +334,8 @@ function getLifetimeDeclarations(
 
 function getConflictsBetweenAccountsAndArguments(instructionNode: InstructionNode): string[] {
     const allNames = [
-        ...instructionNode.accounts.map(account => account.name),
-        ...instructionNode.arguments.map(argument => argument.name),
+        ...(instructionNode.accounts ?? []).map(account => account.name),
+        ...(instructionNode.arguments ?? []).map(argument => argument.name),
     ];
     const duplicates = allNames.filter((e, i, a) => a.indexOf(e) !== i);
     return [...new Set(duplicates)];

--- a/src/visitors/getTypeManifestVisitor.ts
+++ b/src/visitors/getTypeManifestVisitor.ts
@@ -179,7 +179,7 @@ export function getTypeManifestVisitor(options: {
                         throw new Error('Enum type must have a parent name.');
                     }
 
-                    const variants = enumType.variants.map(variant => visit(variant, self));
+                    const variants = (enumType.variants ?? []).map(variant => visit(variant, self));
                     const mergedManifest = mergeManifests(variants);
 
                     return {
@@ -357,7 +357,7 @@ export function getTypeManifestVisitor(options: {
                         throw new Error('Struct type must have a parent name.');
                     }
 
-                    const fields = structType.fields.map(field => visit(field, self));
+                    const fields = (structType.fields ?? []).map(field => visit(field, self));
                     const mergedManifest = mergeManifests(fields);
 
                     if (nestedStruct) {
@@ -385,7 +385,7 @@ export function getTypeManifestVisitor(options: {
                 },
 
                 visitTupleType(tupleType, { self }) {
-                    const items = tupleType.items.map(item => visit(item, self));
+                    const items = (tupleType.items ?? []).map(item => visit(item, self));
                     const mergedManifest = mergeManifests(items);
 
                     return {

--- a/src/visitors/renderValueNodeVisitor.ts
+++ b/src/visitors/renderValueNodeVisitor.ts
@@ -33,7 +33,7 @@ export function renderValueNodeVisitor(
     return {
         visitArrayValue(node) {
             return mergeFragments(
-                node.items.map(v => visit(v, this)),
+                (node.items ?? []).map(v => visit(v, this)),
                 cs => `[${cs.join(', ')}]`,
             );
         },
@@ -75,6 +75,12 @@ export function renderValueNodeVisitor(
             return fragment`${enumName}::${variantName} ${fields}`;
         },
 
+        visitInjectedValue() {
+            // An injected value is resolved by key from a surrounding provider at a later stage,
+            // so it has no concrete Rust rendering here.
+            throw new Error('Unsupported injected value node.');
+        },
+
         visitMapEntryValue(node) {
             const mapKey = visit(node.key, this);
             const mapValue = visit(node.value, this);
@@ -82,7 +88,7 @@ export function renderValueNodeVisitor(
         },
 
         visitMapValue(node) {
-            const entries = node.entries.map(entry => visit(entry, this));
+            const entries = (node.entries ?? []).map(entry => visit(entry, this));
             return addFragmentImports(
                 mergeFragments(entries, cs => `HashMap::from([${cs.join(', ')}])`),
                 ['std::collection::HashMap'],
@@ -102,7 +108,7 @@ export function renderValueNodeVisitor(
         },
 
         visitSetValue(node) {
-            const items = node.items.map(v => visit(v, this));
+            const items = (node.items ?? []).map(v => visit(v, this));
             return addFragmentImports(
                 mergeFragments(items, cs => `HashSet::from([${cs.join(', ')}])`),
                 ['std::collection::HashSet'],
@@ -126,12 +132,12 @@ export function renderValueNodeVisitor(
         },
 
         visitStructValue(node) {
-            const fields = node.fields.map(field => visit(field, this));
+            const fields = (node.fields ?? []).map(field => visit(field, this));
             return mergeFragments(fields, cs => `{ ${cs.join(', ')} }`);
         },
 
         visitTupleValue(node) {
-            const items = node.items.map(v => visit(v, this));
+            const items = (node.items ?? []).map(v => visit(v, this));
             return mergeFragments(items, cs => `(${cs.join(', ')})`);
         },
     };


### PR DESCRIPTION
This PR upgrades the `@codama/*` dependencies to 1.10 and adapts the renderer to `@codama/nodes@1.10`, whose node array attributes are now optional (`Array<T> | undefined`). Array reads are guarded with `?? []` throughout, and the new `injectedValueNode` value kind now throws an explicit unsupported-node error. No new changeset is added because the pending `eager-feet-check.md` changeset already on `main` ("Bump Codama dependencies to the latest version") covers this bump.